### PR TITLE
Fix  #13

### DIFF
--- a/app/Providers/SatisServiceProvider.php
+++ b/app/Providers/SatisServiceProvider.php
@@ -60,6 +60,9 @@ class SatisServiceProvider extends ServiceProvider {
 
                             $output[$package->getName()] = $package->getVersion();
                         }
+                        if(!$output){
+                            return null;   
+                        }
 
                         $type = array('name' => 'array');
 


### PR DESCRIPTION
Return null for empty packages collections so serializer skips this property
