### PR TITLE
Add twig template option for satis.json and a little more Mercurial support

### DIFF
--- a/app/Satis/Model/Config.php
+++ b/app/Satis/Model/Config.php
@@ -60,6 +60,12 @@ class Config {
 	 */
 	private $archive;
 
+    /**
+     * @Type("string")
+     * @SerializedName("twig-template")
+     */
+    private $twigTemplate;
+
 	/**
 	 * Constructor
 	 */
@@ -187,4 +193,23 @@ class Config {
 
 		return $this;
 	}
+
+    /**
+     * @return string
+     */
+    public function getTwigTemplate()
+    {
+        return $this->twigTemplate;
+    }
+
+    /**
+     * @param string $twigTemplate
+     * @return Config
+     */
+    public function setTwigTemplate($twigTemplate)
+    {
+        $this->twigTemplate = $twigTemplate;
+
+        return $this;
+    }
 }

--- a/app/Satis/Model/Repository.php
+++ b/app/Satis/Model/Repository.php
@@ -13,7 +13,7 @@ use JMS\Serializer\Annotation\Type;
 */
 class Repository {
 
-  const REGEX = '#((git|ssh|http(s)?)|(git@[\w.]+))(:(\/\/)?)([\w.@:\/\-~]+)(.git)(\/)?#';
+  const REGEX = '#((git|ssh|http(s)?)|(git@[\w.]+))(:(\/\/)?)([\w.@:\/\-~]+)(\/)?#';
 
   /**
    * @Type("string")

--- a/bin/satis
+++ b/bin/satis
@@ -11,6 +11,10 @@ use Composer\Satis\Console\Application;
 putenv('COMPOSER_HOME=' . $appConfig['composer_home']);
 putenv('COMPOSER_CACHE_DIR=' . $appConfig['composer_cache']);
 
+if (!empty($appConfig['hgrc_path'])) {
+  putenv('HGRCPATH=' . $appConfig['hgrc_path']);
+}
+
 function includeIfExists($file)
 {
     if (file_exists($file)) {

--- a/config/satis.php
+++ b/config/satis.php
@@ -9,6 +9,9 @@ return [
     'composer_home' => base_path(env('COMPOSER_HOME', 'storage' . DIRECTORY_SEPARATOR . 'composer')),
     'composer_cache' => base_path(env('COMPOSER_HOME', 'storage' . DIRECTORY_SEPARATOR . 'composer/cache')),
 
+    // See https://www.selenic.com/mercurial/hg.1.html#environment-variables for how HGRCPATH can be set/used
+    'hgrc_path' => false,
+
     'memory_limit' => '2G',
     'build_verbosity' => 'vvv',
 
@@ -28,7 +31,7 @@ return [
     'default_repository_type' => 'vcs',
 
     'repository_types' => [
-        'vcs', 'pear', 'composer', 'artifact', 'path'
+        'vcs', 'hg', 'pear', 'composer', 'artifact', 'path'
     ],
 
     'build_directory' => base_path('public'),


### PR DESCRIPTION
These are just a few small adjustments I've made to have it handle Mercurial repos as well as being able to use a custom twig template for the Satis output.