### PR TITLE
Add providers.

### DIFF
--- a/app/Satis/ConfigMirror.php
+++ b/app/Satis/ConfigMirror.php
@@ -63,6 +63,7 @@ class ConfigMirror {
 
         $privateConfig->setHomepage(rtrim($homepage, '/') . '/' . config('satis.private_repository'))
             ->setRequireAll(true)
+            ->setProviders(true)
             ->setPackages(new PackageCollection());
 
         return $this->serializer->serialize($privateConfig, 'json');

--- a/app/Satis/Model/Config.php
+++ b/app/Satis/Model/Config.php
@@ -44,6 +44,12 @@ class Config {
 
 	/**
 	 * @Type("boolean")
+	 * @SerializedName("providers")
+	 */
+	private $providers;
+
+	/**
+	 * @Type("boolean")
 	 * @SerializedName("require-dependencies")
 	 */
 	private $requireDependencies;
@@ -191,6 +197,22 @@ class Config {
 	public function setRequireAll($requireAll) {
 		$this->requireAll = $requireAll;
 
+		return $this;
+	}
+
+	/**
+	 * @return boolean
+	 */
+	public function getProviders() {
+		return $this->providers;
+	}
+
+	/**
+	 * @param boolean $providers
+	 * @return $this
+	 */
+	public function setProviders($providers) {
+		$this->providers = $providers;
 		return $this;
 	}
 


### PR DESCRIPTION
Each package will be dumped into a separate include file which will be only loaded by composer when the package is really required.
Speeds up composer handling for repositories with huge number of packages like f.i. packagist.
Also it allow get download statistics for every bundle.

Signed-off-by: Viacheslav Dubrovskyi <vdubrovskyi@oroinc.com>